### PR TITLE
fix: route regex

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 link_regex = re.compile(r'https?://\S+')
-route_regex = re.compile(r'\S+/\d+--\S+/\d+/\d+')
+route_regex = re.compile(r'\S+/\S+--\S+/\d+/\d+')
 
 queue = asyncio.Queue()
 bot = discord.Bot()


### PR DESCRIPTION
`23ab5267243bdaab/0000001f--198a08afae/46/129` is valid